### PR TITLE
Adds get to client to download specific URL from Salesforce

### DIFF
--- a/src/aiosalesforce/client.py
+++ b/src/aiosalesforce/client.py
@@ -236,6 +236,31 @@ class Salesforce:
             if next_url is None:
                 break
 
+    async def get(
+        self,
+        url: str,
+    ) -> bytes:
+        """
+        Get a specific Salesforce URL.
+
+        Parameters
+        ----------
+        url : str
+            Url to get.
+            E.g. "services/data/v60.0/sobjects/EventLogFile/0ATHv000003cMrXABY/LogFile"
+
+        Returns
+        -------
+        bytes
+            Byte representation of results.
+        """
+        if url.startswith("/"):
+            url = url[1:]
+        response = await self.request(
+            "GET", f"{self.base_url}/{url}", headers={"Content-Encoding": "gzip"}
+        )
+        return response.content
+
     @cached_property
     def sobject(self) -> SobjectClient:
         """


### PR DESCRIPTION
Adds get method to client to download specific URL from Salesforce, useful for downloading EventLogFile records.  

Event Log Overview:   https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/using_resources_event_log_files.htm